### PR TITLE
feat: add heartbeat support

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -11,3 +11,8 @@ parserOptions:
   sourceType: module
 plugins:
   - '@typescript-eslint/eslint-plugin'
+rules:
+  - '@typescript-eslint/interface-name-prefix':
+    - error
+    - prefixWithI: always
+      allowUnderscorePrefix: true

--- a/lib/heart-beat.ts
+++ b/lib/heart-beat.ts
@@ -1,0 +1,52 @@
+import { EventEmitter } from 'events'
+import { isOnline } from './online-status'
+
+interface IMonitorOptions {
+    timeout: number,
+    callback(): boolean
+}
+
+interface IMonitor {
+    start (): EventEmitter,
+    stop (): EventEmitter
+}
+
+interface IStartBeat {
+    (): EventEmitter
+}
+
+const TIMEOUT = 3000 // 3s
+const DEFAULT_OPTIONS: IMonitorOptions = {
+    timeout: TIMEOUT,
+    callback: (): boolean => true
+}
+const notify: EventEmitter = new EventEmitter()
+let timeoutId: number|undefined = undefined
+
+function startBeat (options: IMonitorOptions = DEFAULT_OPTIONS): IStartBeat {
+    if (options && (typeof options.callback === 'function')) {
+        timeoutId = setTimeout((): void => {
+            const isAlive = options.callback() === true
+            notify.emit('status', isOnline() && isAlive)
+            startBeat(options)
+        }, options.timeout)
+    }
+
+    return function start (): EventEmitter {
+        return notify
+    }
+}
+
+function stopBeat (): EventEmitter {
+    clearTimeout(timeoutId)
+    return notify
+}
+
+export function monitor (options: IMonitorOptions = DEFAULT_OPTIONS): IMonitor {
+    const start = startBeat(options)
+
+    return {
+        start,
+        stop: stopBeat
+    }
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,1 +1,2 @@
 export { isOnline, start, stop } from './online-status'
+export { monitor } from './heart-beat'


### PR DESCRIPTION
Support for custom heartbeat check. Say you wanted to ping the server to ensure its 200 OK and ensure that we're still online.

Use case is if the application server is down; but customer internet is online.

```javascript

import { isOnline, monitor } from 'online-status-event'

function handleHeartBeatStatus (status) {
  if (status) {
    // do something if it's online
  } else {
    // do something if it's online
  }

  console.log('Valid connection', status)
}

const heartBeat = monitor({
  callback: function () { // This is your function that needs to return true or false
    const greaterThanEqualFive = Math.floor((Math.random() * 10)
    return greaterThanEqualFive >= 5
  }
})

heartBeat.start().on('status', handleHeartBeatStatus)
// You can also stop the beat -> heartBeat.stop()
```